### PR TITLE
Add Amplitude transition to volta

### DIFF
--- a/tests/test_swaptest.py
+++ b/tests/test_swaptest.py
@@ -10,7 +10,11 @@
 import unittest
 from qiskit import QuantumCircuit, BasicAer
 from qiskit.utils import QuantumInstance
-from volta.swaptest import measure_swap_test, measure_dswap_test
+from volta.swaptest import (
+    measure_swap_test,
+    measure_dswap_test,
+    measure_amplitude_transition_test,
+)
 
 
 class TestSWAPTest(unittest.TestCase):
@@ -86,6 +90,44 @@ class TestDestructiveSWAPTest(unittest.TestCase):
     def test_11states(self):
         want = 1.0
         got = measure_dswap_test(self.qc1, self.qc1, self.backend)
+        decimalPlace = 2
+        message = "Swap test not working for states 1 and 1."
+        self.assertAlmostEqual(want, got, decimalPlace, message)
+
+
+class TestAmplitudeTransitionTest(unittest.TestCase):
+    def setUp(self):
+        self.qc1 = QuantumCircuit(1)
+        self.qc1.x(0)
+        self.qc2 = QuantumCircuit(1)
+        self.backend = QuantumInstance(
+            backend=BasicAer.get_backend("qasm_simulator"), shots=10000
+        )
+
+    def test_10states(self):
+        want = 0.0
+        got = measure_amplitude_transition_test(self.qc2, self.qc1, self.backend)
+        decimalPlace = 1
+        message = "Swap test not working for states 0 and 1."
+        self.assertAlmostEqual(want, got, decimalPlace, message)
+
+    def test_01states(self):
+        want = 0.0
+        got = measure_amplitude_transition_test(self.qc1, self.qc2, self.backend)
+        decimalPlace = 1
+        message = "Swap test not working for states 0 and 1."
+        self.assertAlmostEqual(want, got, decimalPlace, message)
+
+    def test_00states(self):
+        want = 1.0
+        got = measure_amplitude_transition_test(self.qc2, self.qc2, self.backend)
+        decimalPlace = 2
+        message = "Swap test not working for states 0 and 0."
+        self.assertAlmostEqual(want, got, decimalPlace, message)
+
+    def test_11states(self):
+        want = 1.0
+        got = measure_amplitude_transition_test(self.qc1, self.qc1, self.backend)
         decimalPlace = 2
         message = "Swap test not working for states 1 and 1."
         self.assertAlmostEqual(want, got, decimalPlace, message)

--- a/tests/test_vqd.py
+++ b/tests/test_vqd.py
@@ -171,12 +171,7 @@ class VQDRaiseError(unittest.TestCase):
 
         hamiltonian = 1 / 2 * (Z ^ I) + 1 / 2 * (Z ^ Z)
         ansatz = TwoLocal(hamiltonian.num_qubits, ["ry", "rz"], "cx", reps=2)
-
-        IMPLEMENTED_OVERLAP_METHODS = ["swap", "dswap", "amplitude"]
-        self.assertRaises(
-            NotImplementedError(
-                f"overlapping method not implemented. Available implementing methods: {IMPLEMENTED_OVERLAP_METHODS}"
-            ),
+        with self.assertRaises(NotImplementedError):
             VQD(
                 hamiltonian=hamiltonian,
                 ansatz=ansatz,
@@ -186,7 +181,6 @@ class VQDRaiseError(unittest.TestCase):
                 backend=backend,
                 overlap_method="test",
             ),
-        )
 
 
 if __name__ == "__main__":

--- a/tests/test_vqd.py
+++ b/tests/test_vqd.py
@@ -146,7 +146,7 @@ class TestVQDAmplitude(unittest.TestCase):
             want,
             got,
             decimal_place,
-            "VQD with DSWAP not working for the ground state of 1/2*((Z^I) + (Z^Z))",
+            "VQD with Excitation Amplitude not working for the ground state of 1/2*((Z^I) + (Z^Z))",
         )
 
     def test_energies_1(self):
@@ -158,7 +158,7 @@ class TestVQDAmplitude(unittest.TestCase):
             want,
             got,
             decimal_place,
-            "VQD with DSWAP not working for the first excited state of 1/2*((Z^I) + (Z^Z))",
+            "VQD with Excitation Amplitude not working for the first excited state of 1/2*((Z^I) + (Z^Z))",
         )
 
 


### PR DESCRIPTION
Closes #9 

This adds a method to `volta.swap_test` called `measure_amplitude_transition_test` which measures the overlap between two circuits by applying the first circuit and then the inverse of the second circuit. 

This also adds a new argument on `volta.vqd.VQD` called `overlap_method` which now supports `dswap`, `swap`, and `amplitude`. 

Tests were added for both  `VQD` and `measure_amplitude_transition_test`.